### PR TITLE
fix(10): make docker-compose detection lazy so --dry-run needs no compose

### DIFF
--- a/src/jote/compose.py
+++ b/src/jote/compose.py
@@ -158,7 +158,10 @@ class Compose:
         self._user_id: Optional[int] = user_id
         self._group_id: Optional[int] = group_id
 
-        assert Compose.try_to_set_compose_command()
+        # Note: we deliberately do *not* probe for the docker-compose command
+        # here. Detection is lazy (see 'run()' and the group helpers) so that
+        # constructing the harness - as a '--dry-run' does - neither requires
+        # docker-compose to be installed nor risks a transient probe timeout.
 
     def get_test_path(self) -> str:
         """Returns the path to the root directory for a given test."""

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -1,0 +1,45 @@
+"""Tests for the jote 'compose' module.
+
+These focus on the requirement (issue #10) that constructing the Compose
+harness (as done during a '--dry-run') must not probe 'docker compose'.
+"""
+
+from unittest import mock
+
+from jote.compose import Compose
+
+
+def _make_compose() -> Compose:
+    return Compose(
+        collection="collection",
+        job="job",
+        test="test",
+        image="image:1.0.0",
+        image_type="simple",
+        memory="1Gi",
+        cores=1,
+        project_directory="/data",
+        working_directory="/data",
+        command="echo hello",
+        environment={},
+    )
+
+
+def test_construction_does_not_probe_docker_compose():
+    # Given a patched docker-compose probe
+    with mock.patch("jote.compose._get_docker_compose_command") as probe:
+        # When we construct a Compose harness (as '--dry-run' does)
+        _make_compose()
+        # Then the docker-compose command must not have been probed
+        probe.assert_not_called()
+
+
+def test_create_does_not_probe_docker_compose(tmp_path, monkeypatch):
+    # Given a working directory and a patched docker-compose probe
+    monkeypatch.chdir(tmp_path)
+    with mock.patch("jote.compose._get_docker_compose_command") as probe:
+        # When we construct and 'create()' the test environment
+        compose = _make_compose()
+        compose.create()
+        # Then the docker-compose command must not have been probed
+        probe.assert_not_called()


### PR DESCRIPTION
Fixes #10

## Problem

`jote --dry-run` (which should only parse and validate Job Definitions
against the schema) still invoked `docker compose`. `Compose.__init__`
called `try_to_set_compose_command()` → `_get_docker_compose_command()`,
which probes `docker compose` via `subprocess.run(...)`. This meant a
dry-run both required docker-compose to be installed and could fail
transiently with `TimeoutExpired` on a slow/loaded runner.

## Fix

Make docker-compose command detection fully lazy by removing the probe
from `Compose.__init__`. Detection is already performed on demand in
`run()` and the group compose helpers (`run_group_compose_file`,
`stop_group_compose_file`), so constructing the harness and creating the
test directory (as a dry-run does) no longer touches docker-compose.
Real test runs still detect and require the command exactly as before.

## Tests

Added `tests/test_compose.py`:

- constructing `Compose` does not probe `docker compose`
- `Compose.create()` does not probe `docker compose`

Both fail before the change and pass after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
